### PR TITLE
Add support for rustc older than 1.61

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [stable, 1.61.0]
+        rust: [stable, 1.61.0, 1.34.0]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,10 @@ authors = ["David Tolnay <dtolnay@gmail.com>"]
 categories = ["no-std", "no-std::no-alloc"]
 description = "Const TypeId and non-'static TypeId"
 documentation = "https://docs.rs/typeid"
-edition = "2021"
+edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/typeid"
-rust-version = "1.61"
+rust-version = "1.34"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,33 @@
+use std::env;
+use std::process::Command;
+use std::str;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let compiler = match rustc_minor_version() {
+        Some(compiler) => compiler,
+        None => return,
+    };
+
+    if compiler >= 80 {
+        println!("cargo:rustc-check-cfg=cfg(no_const_type_id)");
+    }
+
+    if compiler < 61 {
+        // Function pointer casting in const fn.
+        // https://blog.rust-lang.org/2022/05/19/Rust-1.61.0.html#more-capabilities-for-const-fn
+        println!("cargo:rustc-cfg=no_const_type_id");
+    }
+}
+
+fn rustc_minor_version() -> Option<u32> {
+    let rustc = env::var_os("RUSTC")?;
+    let output = Command::new(rustc).arg("--version").output().ok()?;
+    let version = str::from_utf8(&output.stdout).ok()?;
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+    pieces.next()?.parse().ok()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,17 +112,22 @@
 extern crate self as typeid;
 
 use core::any::TypeId;
+#[cfg(not(no_const_type_id))]
 use core::cmp::Ordering;
+#[cfg(not(no_const_type_id))]
 use core::fmt::{self, Debug};
+#[cfg(not(no_const_type_id))]
 use core::hash::{Hash, Hasher};
 use core::marker::PhantomData;
 use core::mem;
 
+#[cfg(not(no_const_type_id))]
 #[derive(Copy, Clone)]
 pub struct ConstTypeId {
     type_id_fn: fn() -> TypeId,
 }
 
+#[cfg(not(no_const_type_id))]
 impl ConstTypeId {
     #[must_use]
     pub const fn of<T>() -> Self
@@ -140,12 +145,14 @@ impl ConstTypeId {
     }
 }
 
+#[cfg(not(no_const_type_id))]
 impl Debug for ConstTypeId {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         Debug::fmt(&self.get(), formatter)
     }
 }
 
+#[cfg(not(no_const_type_id))]
 impl PartialEq for ConstTypeId {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
@@ -153,14 +160,17 @@ impl PartialEq for ConstTypeId {
     }
 }
 
+#[cfg(not(no_const_type_id))]
 impl PartialEq<TypeId> for ConstTypeId {
     fn eq(&self, other: &TypeId) -> bool {
         self.get() == *other
     }
 }
 
+#[cfg(not(no_const_type_id))]
 impl Eq for ConstTypeId {}
 
+#[cfg(not(no_const_type_id))]
 impl PartialOrd for ConstTypeId {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
@@ -168,6 +178,7 @@ impl PartialOrd for ConstTypeId {
     }
 }
 
+#[cfg(not(no_const_type_id))]
 impl Ord for ConstTypeId {
     #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
@@ -175,6 +186,7 @@ impl Ord for ConstTypeId {
     }
 }
 
+#[cfg(not(no_const_type_id))]
 impl Hash for ConstTypeId {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.get().hash(state);


### PR DESCRIPTION
I am interested in using `typeid` in a crate that currently targets Rust 1.60. This part of the implementation isn't compatible with that:

```console
error[E0658]: function pointer casts are not allowed in constant functions
   --> src/lib.rs:133:25
    |
133 |             type_id_fn: typeid::of::<T>,
    |                         ^^^^^^^^^^^^^^^
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
```