### PR TITLE
Forcibly inline vtable access

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@
 
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/typeid/1.0.1")]
-#![allow(clippy::doc_markdown)]
+#![allow(clippy::doc_markdown, clippy::inline_always)]
 
 extern crate self as typeid;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,7 @@ impl Hash for ConstTypeId {
 }
 
 #[must_use]
+#[inline(always)]
 pub fn of<T>() -> TypeId
 where
     T: ?Sized,
@@ -205,6 +206,7 @@ where
     }
 
     impl<T: ?Sized> NonStaticAny for PhantomData<T> {
+        #[inline(always)]
         fn get_type_id(&self) -> TypeId
         where
             Self: 'static,


### PR DESCRIPTION
See #2. This makes `typeid::of::<T>()` generate identical machine code as `TypeId::of::<T>()` at all optimization levels including `-Copt-level=0`.