### PR TITLE
Safe implementation (arbitrary_self_types)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,26 +17,18 @@ jobs:
     uses: dtolnay/.github/.github/workflows/pre_ci.yml@master
 
   test:
-    name: Rust ${{matrix.rust}}
+    name: Rust nightly
     needs: pre_ci
     if: needs.pre_ci.outputs.continue
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        rust: [nightly, beta, stable, 1.79.0, 1.61.0, 1.34.0]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{matrix.rust}}
+      - uses: dtolnay/rust-toolchain@nightly
       - name: Enable type layout randomization
         run: echo RUSTFLAGS=${RUSTFLAGS}\ -Zrandomize-layout >> $GITHUB_ENV
-        if: matrix.rust == 'nightly'
       - run: cargo check
       - run: cargo test
-        if: matrix.rust != '1.61.0' && matrix.rust != '1.34.0'
 
   doc:
     name: Documentation


### PR DESCRIPTION
By @steffahn in [_"How “important” is the \`T: 'static\` bound for \`TypeId::of\`?"_](https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/topic/How.20.E2.80.9Cimportant.E2.80.9D.20is.20the.20.60T.3A.20'static.60.20bound.20for.60TypeId.3A.3Aof.60.3F)